### PR TITLE
Preventing a data race in window size change.

### DIFF
--- a/SSHTermbox/api.go
+++ b/SSHTermbox/api.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"log"
+	"sync"
 
 	"github.com/mattn/go-runewidth"
 )
@@ -38,6 +39,7 @@ type Termbox struct {
 
 	newW int
 	newH int
+	sizeLock sync.Mutex
 
 	// grayscale indexes
 	grayscale []Attribute
@@ -287,7 +289,6 @@ func (t *Termbox) PollRawEvent(data []byte) Event {
 			event.Type = EventInterrupt
 			return event
 		case ev := <-t.resize_comm:
-			t.update_size_maybe()
 			return ev
 		}
 	}
@@ -330,7 +331,6 @@ func (t *Termbox) PollEvent() Event {
 			return event
 
 		case ev := <-t.resize_comm:
-			t.update_size_maybe()
 			return ev
 		}
 	}

--- a/SSHTermbox/termbox.go
+++ b/SSHTermbox/termbox.go
@@ -201,14 +201,20 @@ func (t *Termbox) send_clear() error {
 }
 
 func (t *Termbox) Resize(newW, newH int) {
+	t.sizeLock.Lock()
 	if t.newW != newW || t.newH != newH {
 		t.newW, t.newH = newW, newH
+		t.sizeLock.Unlock()
 		t.resize_comm <- Event{Type: EventResize, Width: newW, Height: newH}
+	} else {
+		t.sizeLock.Unlock()
 	}
 }
 
 func (t *Termbox) update_size_maybe() error {
+	t.sizeLock.Lock()
 	w, h := t.newW, t.newH
+	t.sizeLock.Unlock()
 	if w != t.termw || h != t.termh {
 		t.termw, t.termh = w, h
 		t.back_buffer.resize(w, h, t.foreground, t.background)


### PR DESCRIPTION
Resize() can get called from a goroutine that is not the primary client
of the termbox, e.g. an ssh session recieving a window change event.
This change places a mutex around the newW/newH variables so that there
won't be a race between writing them on the ssh session goroutine and
reading them in the termbox client.  This also changes PollEvent and
PollRawEvent to not change the backbuffer/frontbuffer sizes when a
window size change event is recieved, as some termbox clients process
events in a separate goroutine from the goroutine that is writing to
the the buffers and flushing the buffers.